### PR TITLE
Package qemu

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,149 @@
+# Copyright 2024 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: build
+on: [ push ]
+permissions:
+  contents: read
+jobs:
+  macos:
+    strategy:
+      matrix:
+        include:
+        - { arch: aarch64, runs-on: macos-14 }
+        - { arch: x86_64, runs-on: macos-13 }
+    runs-on: ${{ matrix.runs-on }}
+    timeout-minutes: 40
+    steps:
+    - run: mkdir -p build
+    - run: brew install filemonitor ninja
+    - run: brew install --ignore-dependencies lima # Don't pull in qemu
+    - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
+    - run: brew install --build-from-source ./qemu.rb
+      env:
+        HOMEBREW_DEBUG: 1
+        HOMEBREW_VERBOSE: 1
+      timeout-minutes: 20
+    - run: cpan -Ti JSON
+    - run: echo "$PWD/install/bin" >> "$GITHUB_PATH"
+    - run: perl lima-and-qemu.pl alpine
+      timeout-minutes: 10
+    - uses: actions/upload-artifact@v4
+      with:
+        name: qemu-darwin-${{ matrix.arch }}
+        path: qemu-darwin-${{ matrix.arch }}.tar.gz
+        if-no-files-found: error
+  linux:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 60
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
+    - uses: actions/checkout@v4
+      with:
+        repository: qemu/qemu
+        ref: v9.1.0
+        path: qemu
+    - name: Install dependencies
+      run: >-
+        sudo apt-get update &&
+        sudo apt-get install -y
+        ninja-build
+        libattr1
+        libattr1-dev
+    - run: mkdir build
+    - run: >-
+        ../qemu/configure
+        --prefix=/usr
+        --target-list=x86_64-softmmu
+        --disable-alsa
+        --disable-bochs
+        --disable-cloop
+        --disable-curses
+        --disable-dbus-display
+        --disable-dmg
+        --disable-gcrypt
+        --disable-guest-agent
+        --disable-iconv
+        --disable-jack
+        --disable-keyring
+        --disable-l2tpv3
+        --disable-oss
+        --disable-pa
+        --disable-parallels
+        --disable-pipewire
+        --disable-pixman
+        --disable-plugins
+        --disable-png
+        --disable-qcow1
+        --disable-qed
+        --disable-replication
+        --disable-selinux
+        --disable-sndio
+        --disable-user
+        --disable-vdi
+        --disable-vduse-blk-export
+        --disable-vhdx
+        --disable-vmdk
+        --disable-vnc
+        --disable-vpc
+        --disable-vvfat
+        --disable-xen
+        --disable-zstd
+        --enable-slirp
+        --enable-virtfs
+      working-directory: build
+    - run: cat meson-logs/meson-log.txt
+      working-directory: build
+      if: failure()
+    - run: ninja
+      working-directory: build
+      timeout-minutes: 60
+    - run: make install DESTDIR=${{ github.workspace }}/install
+      working-directory: build
+    - run: ./appdir-qemu.sh "${{ github.workspace }}/install/usr"
+    - uses: actions/upload-artifact@v4
+      with:
+        name: qemu-linux-x86_64
+        path: qemu-linux-x86_64.tar.gz
+        if-no-files-found: error
+  release:
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: [macos, linux]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+    - uses: actions/download-artifact@v4
+      with:
+        merge-multiple: true
+    - name: Generate checksums
+      run: |
+        for i in qemu-*.tar.gz; do
+          sha512sum -b "$i" > "$i.sha512sum"
+        done
+    - name: Create release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: >-
+        gh release create
+        "${{ github.ref_name }}"
+        qemu-*.tar.gz
+        qemu-*.tar.gz.sha512sum
+        --draft
+        --title "${{ github.ref_name }}"
+        --repo "${{ github.repository }}"

--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+# rancher-desktop-qemu
+
+This repository contains scripts to package qemu for use with Rancher Desktop.
+
+Packaging is automatically done via [GitHub Actions] on push.  If the push is
+a tag, a draft release is created with that tag.
+
+[GitHub Actions]: .github/workflows/build.yaml

--- a/appdir-qemu.sh
+++ b/appdir-qemu.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+
+# Copyright 2024 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# From https://github.com/rancher-sandbox/lima-and-qemu/blob/d874fe62584dcfa7e5fdd45f5225853a0240bd26/bin/appdir-lima-and-qemu.sh
+
+# This is a helper script to build an appDir structure to include qemu as part
+# of an AppImage binary.  The binaries build should happen in the oldest
+# available Ubuntu LTS.
+
+function error {
+  >&2 echo "$@"
+  exit 1
+}
+
+function keepListedFiles {
+  local dir=$1
+  local list=$2
+
+  [ -d "${dir}" ] || error "${dir} is not a directory"
+
+  for it in "${dir}"/*; do
+    it=${it#"$dir"/}
+    if [[ "${list}" =~ \ ${it}\  ]]; then
+      continue
+    fi
+    [ -n "${it}" ] && rm -rf "${dir:?}/${it}"
+  done
+}
+
+set -ex
+
+[ -n "${1}" ] || error "One argument to the built app dir is required"
+[ -d "${1}" ] || error "Directory ${1} doesn't exist"
+
+appDir=$1
+dist="qemu-linux-x86_64"
+
+# Inspired on linuxdeployqt https://github.com/probonopd/linuxdeployqt/blob/master/tools/linuxdeployqt/excludelist.h
+# Linuxdeployqt is a tool created by probonopd, the AppImage creator
+excludeLibs=" libz.so.1 "
+excludeLibs+="libgio-2.0.so.0 "
+excludeLibs+="libgobject-2.0.so.0 "
+excludeLibs+="libglib-2.0.so.0 "
+excludeLibs+="libutil.so.1 "
+excludeLibs+="libm.so.6 "
+excludeLibs+="libgcc_s.so.1 "
+excludeLibs+="libpthread.so.0 "
+excludeLibs+="libc.so.6 "
+excludeLibs+="libresolv.so.2 "
+excludeLibs+="libdl.so.2 "
+excludeLibs+="librt.so.1 "
+excludeLibs+="libuuid.so.1 "
+excludeLibs+="libdl.so.2 "
+excludeLibs+="libgmodule-2.0.so.0 "
+
+firmwareOfInterest=" bios-256k.bin edk2-x86_64-code.fd efi-virtio.rom kvmvapic.bin vgabios-virtio.bin "
+executablesOfInterest=" qemu-system-x86_64 qemu-img "
+
+mkdir -p "${appDir}/lib"
+
+linkedLibs=$(ldd "${appDir}/bin/qemu-system-x86_64" | grep " => /" | cut -d" " -f3)$'\n'
+linkedLibs+=$(ldd "${appDir}/bin/qemu-img" | grep " => /" | cut -d" " -f3)$'\n'
+for lib in $(echo "${linkedLibs}" | sort | uniq ); do
+  if [[ "${excludeLibs}" =~ \ $(basename ${lib})\  ]]; then
+    continue
+  fi
+  cp "${lib}" "${appDir}/lib"
+done
+
+# strip docs
+rm -rf "${appDir:?}/share/doc"
+
+# remove qemu icons, includes, etc.
+# We could fine tune the firmaware files
+rm -rf "${appDir:?}/include"
+rm -rf "${appDir:?}/libexec"
+rm -rf "${appDir:?}/var"
+rm -rf "${appDir:?}/share/applications"
+rm -rf "${appDir:?}/share/icons"
+
+# keep only relevant firmware
+keepListedFiles "${appDir}/share/qemu" "${firmwareOfInterest}"
+
+# keep only relevant executables
+keepListedFiles "${appDir}/bin" "${executablesOfInterest}"
+
+tar caf "${dist}.tar.gz" -C "${appDir}" .

--- a/lima-and-qemu.pl
+++ b/lima-and-qemu.pl
@@ -1,0 +1,250 @@
+#!/usr/bin/env perl
+
+# Copyright 2024 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Adapted from https://github.com/runfinch/finch-core/blob/95fce20b69f0/bin/lima-and-qemu.pl
+# Itself adapted from https://github.com/rancher-sandbox/lima-and-qemu/blob/c4e3bb286c7/bin/lima-and-qemu.pl
+
+#!/usr/bin/env perl
+use strict;
+use warnings;
+
+use FindBin qw();
+use JSON qw( decode_json );
+
+my $proc = qx(uname -p);
+my $arch = $proc =~ /86/ ? "x86_64" : "aarch64";
+
+# By default capture both legacy firmware (alpine) and UFI (default) usage
+@ARGV = qw(alpine default) unless @ARGV;
+
+# This script creates a tarball containing qemu as launched by lima, plus all its
+# dependencies from /usr/local/** or /opt/homebrew/.
+# Files opened by limactl and qemu are captured using https://github.com/objective-see/FileMonitor
+# `limactl start examples/alpine.yaml; limactl stop alpine; limactrl delete alpine`.
+
+# {"event":"ES_EVENT_TYPE_NOTIFY_WRITE","timestamp":"2022-11-02 02:19:42 +0000","file":
+# {"destination":"/Users/siravara/.lima/default/cidata.iso","
+# process":{"pid":35515,"name":"limactl","path":"/opt/homebrew/bin/limactl",
+# "uid":504,"architecture":"Apple Silicon","arguments":[],"ppid":35512,"rpid":812,"ancestors"
+# :[812,1],"signing info (reported)":{"csFlags":570556419,"platformBinary":0,"signingID":"a.out","teamID":"",
+# "cdHash":"37B6887F5188C68A1A072989289EAFDB8B68C75A"},"signing info (computed)":{"signatureStatus":0,"signatureSigner":
+# "AdHoc","signatureID":"a.out"}}}}
+#
+# It shows the following binaries from /usr/local are called:
+
+my %deps;
+chomp(my $install_dir = qx(brew --prefix));
+record("$install_dir/bin/qemu-img");
+record("$install_dir/bin/qemu-system-$arch");
+
+# qemu 6.1.0 doesn't use the symlink to access data files anymore
+# but we need to include it because we replace the symlinks in
+# /usr/local/bin with the actual files, so data file references need
+# to resolve relative to that location too.
+my $name = "$install_dir/share/qemu";
+# Don't call record($name) because we only want the link, not the whole target directory
+$deps{$name} = "→ " . readlink($name);
+
+# Capture any library and datafiles access with FileMonitor
+my $filemonitor = "/tmp/filemonitor.log";
+END { system("sudo pkill FileMonitor") }
+print "sudo may prompt for password to run FileMonitor\n";
+
+#Change this FileMonitor path for local build to installed path
+system("sudo -b filemonitor -skipApple >$filemonitor 2>/dev/null");
+sleep(1) until -s $filemonitor;
+
+chomp(my $lima_dir = qx(brew --prefix lima));
+for my $example (@ARGV) {
+    my $config = "$lima_dir/share/lima/templates/$example.yaml";
+    die "Config $config not found" unless -f $config;
+    system("limactl delete -f $example") if -d "$ENV{HOME}/.lima/$example";
+    system("limactl start --tty=false --cpus 2 --log-level debug $config");
+    system("limactl shell $example uname");
+    system("limactl stop $example");
+    system("limactl delete $example");
+}
+system("sudo pkill FileMonitor");
+
+sleep 10;
+
+open(my $fh, "<", $filemonitor) or die "Can't read $filemonitor: $!";
+while (my $line = <$fh>) {
+    # Only record files opened by qemu-*
+    my $decoded_json;
+    {
+        local $@;
+        eval { $decoded_json = decode_json($line) };
+        next if $@;
+    }
+    my $processName = $decoded_json->{'file'}{'process'}{'name'};
+    my $fileName = $decoded_json->{'file'}{'destination'};
+    next unless $processName =~ /^\s*qemu-/;
+
+    # Skip /opt/homebrew/bin and /usr/local/bin
+    next if $fileName eq "$install_dir/bin";
+    # Ignore files not under /usr/local or /opt/homebrew
+    next unless $fileName =~ /^.*($install_dir\/\S+).*$/;
+    # Skip files that don't exist
+    next unless -e $fileName;
+
+    #Skip if file is already recorded
+    next if exists($deps{$fileName});
+    print "Filename: $fileName \n";
+
+    # find all links of $filename and record.
+    my $links = `find -L  $install_dir/opt -samefile $fileName`;
+    record($fileName);
+    my @arr = split('\n', $links);
+    for my $link (@arr) {
+        #skip if link is already recorded
+        next if exists($deps{$link});
+        record($link);
+    }
+}
+
+# Temporary hack because we can't run qemu aarch64 in CI
+if ($arch eq "aarch64") {
+    chomp(my $qemu_dir = qx(brew --prefix qemu));
+    record("$qemu_dir/share/qemu/kvmvapic.bin");
+    record("$qemu_dir/share/qemu/efi-virtio.rom");
+    record("$qemu_dir/share/qemu/vgabios-virtio.bin");
+}
+
+print "$_ $deps{$_}\n" for sort keys %deps;
+print "\n";
+
+my $dist = "qemu-darwin-$arch";
+system("rm -rf /tmp/$dist");
+
+# Copy all files to /tmp tree and make all dylib references relative to the
+# /usr/local/bin directory using @executable_path/..
+my %resign;
+for my $file (keys %deps) {
+    my $copy = $file =~ s|^$install_dir|/tmp/$dist|r;
+    system("mkdir -p " . dirname($copy));
+    if ($file =~ m|^$install_dir/bin/|) {
+        # symlinks in the bin directory are replaced by the target file because in
+        # macOS Monterey @executable_path refers to the symlink target and not the
+        # symlink location itself, breaking the dylib lookup.
+        system("cp $file $copy");
+    }
+    else {
+        system("cp -R $file $copy");
+        next if -l $file;
+    }
+    next unless qx(file $copy) =~ /Mach-O/;
+
+    open(my $fh, "otool -L $file |") or die "Failed to run 'otool -L $file': $!";
+    while (<$fh>) {
+        my($dylib) = m|$install_dir/(\S+)| or next;
+        my $grep = "";
+        if ($file =~ m|bin/qemu-system-$arch$|) {
+            # qemu-system-* is already signed with an entitlement to use the hypervisor framework
+            $grep = "| grep -v 'will invalidate the code signature'";
+            $resign{$copy}++;
+        }
+        $resign{$copy}++ if $arch eq "aarch64";
+        system "install_name_tool -change $install_dir/$dylib \@executable_path/../$dylib $copy 2>&1 $grep";
+    }
+    close($fh);
+}
+# Replace invalidated signatures
+for my $file (keys %resign) {
+    system("codesign --sign - --force --preserve-metadata=entitlements $file");
+}
+
+my $files = join(" ", map s|^$install_dir/||r, keys %deps);
+
+
+# Package socket_vmnet
+die if -e "/tmp/$dist/socket_vmnet";
+if (-f "/opt/socket_vmnet/bin/socket_vmnet") {
+    system("mkdir -p /tmp/$dist/socket_vmnet/bin");
+    system("cp /opt/socket_vmnet/bin/socket_vmnet /tmp/$dist/socket_vmnet/bin/socket_vmnet");
+    $files .= " socket_vmnet/bin/socket_vmnet";
+}
+
+# Ensure all files are writable by the owner; this is required for Squirrel.Mac
+# to remove the quarantine xattr when applying updates.
+system("chmod -R u+w /tmp/$dist");
+
+# Remove Finder-related xattrs from files; having them causes code signing to
+# fail, with the message:
+# > resource fork, Finder information, or similar detritus not allowed
+for my $attr (("com.apple.FinderInfo", "com.apple.ResourceFork")) {
+    system("xattr -drs $attr /tmp/$dist");
+}
+
+my $repo_root = $FindBin::Bin;
+unlink("$repo_root/$dist.tar.gz");
+system("tar cvfz $repo_root/$dist.tar.gz -C /tmp/$dist $files");
+
+exit;
+
+# File references may involve multiple symlinks that need to be recorded as well, e.g.
+#
+#   /usr/local/opt/libssh/lib/libssh.4.dylib
+#
+# turns into 2 symlinks and one file:
+#
+#   /usr/local/opt/libssh → ../Cellar/libssh/0.9.5_1
+#   /usr/local/Cellar/libssh/0.9.5_1/lib/libssh.4.dylib → libssh.4.8.6.dylib
+#   /usr/local/Cellar/libssh/0.9.5_1/lib/libssh.4.8.6.dylib [394K]
+
+my %seen;
+sub record {
+    my $dep = shift;
+    return if $seen{$dep}++;
+    $dep =~ s|^/|| or die "$dep is not an absolute path";
+    my $filename = "";
+    my @segments = split '/', $dep;
+    while (@segments) {
+        my $segment = shift @segments;
+        my $name = "$filename/$segment";
+        my $link = readlink $name;
+        # symlinks in the bin directory are replaced by the target, and the symlinks are not
+        # recorded (see above). However, at least "share/qemu" needs to remain a symlink to
+        # "../Cellar/qemu/6.0.0/share/qemu" so qemu will still find its data files. Therefore
+        # symlinks are still recorded for all other files.
+        if (defined $link && $name !~ m|^$install_dir/bin/|) {
+            # Record the symlink itself with the link target as the comment
+            $deps{$name} = "→ $link";
+            if ($link =~ m|^/|) {
+                # Can't support absolute links pointing outside /usr/local
+                die "$name → $link" unless $link =~ m|^$install_dir/|;
+                $link = join("/", $link, @segments);
+            } else {
+                $link = join("/", $filename, $link, @segments);
+            }
+            # Re-parse from the start because the link may contain ".." segments
+            return record($link)
+        }
+        if ($segment eq "..") {
+            $filename = dirname($filename);
+        } else {
+            $filename = $name;
+        }
+    }
+    # Use human readable size of the file as the comment:
+    # $ ls -lh /usr/local/Cellar/libssh/0.9.5_1/lib/libssh.4.8.6.dylib
+    # -rw-r--r--  1 jan  staff   394K  5 Jan 11:04 /usr/local/Cellar/libssh/0.9.5_1/lib/libssh.4.8.6.dylib
+    $deps{$filename} = sprintf "[%s]", (split / +/, qx(ls -lh $filename))[4];
+}
+
+sub dirname {
+    shift =~ s|/[^/]+$||r;
+}

--- a/qemu.rb
+++ b/qemu.rb
@@ -1,0 +1,108 @@
+# This file was modified from Homebrew-core, with the given license:
+#
+# BSD 2-Clause License
+#
+# Copyright (c) 2009-present, Homebrew contributors
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+class Qemu < Formula
+  desc "Generic machine emulator and virtualizer"
+  homepage "https://www.qemu.org/"
+  url "https://download.qemu.org/qemu-9.1.0.tar.xz"
+  sha256 "816b7022a8ba7c2ac30e2e0cf973e826f6bcc8505339603212c5ede8e94d7834"
+  license "GPL-2.0-only"
+  head "https://gitlab.com/qemu-project/qemu.git", branch: "master"
+
+  livecheck do
+    url "https://www.qemu.org/download/"
+    regex(/href=.*?qemu[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
+  depends_on "libtool" => :build
+  depends_on "meson" => :build
+  depends_on "ninja" => :build
+  depends_on "pkg-config" => :build
+
+  depends_on "glib"
+  depends_on "libslirp"
+
+  uses_from_macos "bison" => :build
+  uses_from_macos "flex" => :build
+  uses_from_macos "bzip2"
+  uses_from_macos "zlib"
+
+  fails_with gcc: "5"
+
+  def install
+    ENV["LIBTOOL"] = "glibtool"
+
+    arch = Hardware::CPU.arm? ? 'aarch64' : 'x86_64'
+
+    args = %W[
+      --prefix=#{prefix}
+      --cc=#{ENV.cc}
+      --host-cc=#{ENV.cc}
+      --target-list=#{arch}-softmmu
+      --disable-auth-pam
+      --disable-bochs
+      --disable-bsd-user
+      --disable-capstone
+      --disable-cloop
+      --disable-cocoa
+      --disable-coreaudio
+      --disable-curl
+      --disable-curses
+      --disable-dbus-display
+      --disable-dmg
+      --disable-gcrypt
+      --disable-gettext
+      --disable-gnutls
+      --disable-guest-agent
+      --disable-iconv
+      --disable-libssh
+      --disable-libusb
+      --disable-nettle
+      --disable-parallels
+      --disable-pixman
+      --disable-png
+      --disable-qcow1
+      --disable-qed
+      --disable-replication
+      --disable-sdl
+      --disable-spice-protocol
+      --disable-vdi
+      --disable-vhdx
+      --disable-vmdk
+      --disable-vnc-jpeg
+      --disable-vpc
+      --disable-vvfat
+      --disable-zstd
+      --enable-slirp
+      --enable-virtfs
+    ]
+
+    system "./configure", *args
+    system "make", "V=1", "install"
+  end
+end


### PR DESCRIPTION
This builds qemu via homebrew, based on upstream formula but limited to just what we need.

Because the aarch64 macOS runners on GitHub do not support virtualization, we hack in a few extra files to include on that platform.  The list of files is based on what the x86_64 run had.

We need slirp because lima uses that (with `--netdev user,...`).

~This just does mac for now.  The result seems to allow Rancher Desktop to start a VM (on macOS aarch64).~

Linux added, because that is required to get E2E Linux tests to pass.