### PR TITLE
Refactor lima and qemu

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -68,8 +68,8 @@ jobs:
         path: qemu-${{ steps.version.outputs.VERSION }}-darwin-source-${{ matrix.arch }}.tar.gz
         if-no-files-found: error
     - run: mkdir -p build
-    - run: brew install filemonitor ninja
-    - run: brew install --ignore-dependencies lima # Don't pull in qemu
+    - run: brew install filemonitor ninja go
+    - run: brew install lima
       env:
         HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
         HOMEBREW_NO_AUTO_UPDATE: 1
@@ -164,6 +164,7 @@ jobs:
       working-directory: build
     - run: ./appdir-qemu.sh "${{ github.workspace }}/install/usr"
       env:
+        LD_LIBRARY_PATH: ${{ github.workspace }}/install/usr/lib/x86_64-linux-gnu
         VERSION: ${{ steps.version.outputs.VERSION }}
     - uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,29 +22,69 @@ jobs:
       matrix:
         include:
         - { arch: aarch64, runs-on: macos-14 }
-        - { arch: x86_64, runs-on: macos-13 }
+        - { arch: x86_64, runs-on: macos-12 }
     runs-on: ${{ matrix.runs-on }}
-    timeout-minutes: 40
+    timeout-minutes: 120
     steps:
-    - run: mkdir -p build
-    - run: brew install filemonitor ninja
-    - run: brew install --ignore-dependencies lima # Don't pull in qemu
     - uses: actions/checkout@v4
       with:
         persist-credentials: false
-    - run: brew install --build-from-source ./qemu.rb
+        fetch-depth: 0
+    - id: version
+      name: Calculate version
+      shell: bash
+      run: |
+        version=$(git describe --match 'v[0-9]*' --dirty='.m' --always --tags)
+        echo "VERSION=${version#v}" >>"$GITHUB_OUTPUT"
+    - name: Uninstall all brew packages and clear cache
+      run: |
+        set -o xtrace
+        brew list | xargs brew uninstall --force
+        brew autoremove
+        brew cleanup
+        rm -rf "$(brew --cache)"
+    - name: Build qemu and all prerequisites from source
+      run: |
+        set -o xtrace
+        brew tap-new rd/tap
+        cp qemu.rb "$(brew --repo rd/tap)/Formula/qemu.rb"
+        brew install --overwrite --build-from-source $(brew deps --include-build python@3.11)  python@3.11
+        brew install --overwrite --build-from-source $(brew deps --include-build python@3.12)  python@3.12
+        brew install --overwrite --build-from-source $(brew deps --include-build python@3.13)  python@3.13
+        brew install --build-from-source $(brew deps --include-build rd/tap/qemu) rd/tap/qemu
+        CACHE=$(brew --cache)
+        cp .github/workflows/build.yaml qemu.rb "$CACHE"
+        (cd "$CACHE"; tar -cvzf - *) >qemu-${{ steps.version.outputs.VERSION }}-darwin-source-${{ matrix.arch }}.tar.gz
       env:
-        HOMEBREW_DEBUG: 1
-        HOMEBREW_VERBOSE: 1
-      timeout-minutes: 20
-    - run: cpan -Ti JSON
-    - run: echo "$PWD/install/bin" >> "$GITHUB_PATH"
-    - run: perl lima-and-qemu.pl alpine
-      timeout-minutes: 10
+        # HOMEBREW_DEBUG: 1
+        # HOMEBREW_VERBOSE: 1
+        HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
+        HOMEBREW_NO_AUTO_UPDATE: 1
+        HOMEBREW_NO_INSTALL_UPGRADE: 1
+        HOMEBREW_NO_INSTALL_CLEANUP: 1
     - uses: actions/upload-artifact@v4
       with:
-        name: qemu-darwin-${{ matrix.arch }}
-        path: qemu-darwin-${{ matrix.arch }}.tar.gz
+        name: qemu-${{ steps.version.outputs.VERSION }}-darwin-source-${{ matrix.arch }}
+        path: qemu-${{ steps.version.outputs.VERSION }}-darwin-source-${{ matrix.arch }}.tar.gz
+        if-no-files-found: error
+    - run: mkdir -p build
+    - run: brew install filemonitor ninja
+    - run: brew install --ignore-dependencies lima # Don't pull in qemu
+      env:
+        HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
+        HOMEBREW_NO_AUTO_UPDATE: 1
+        HOMEBREW_NO_INSTALL_UPGRADE: 1
+        HOMEBREW_NO_INSTALL_CLEANUP: 1
+    - run: cpan -Ti JSON
+    - run: echo "$PWD/install/bin" >>"$GITHUB_PATH"
+    - run: perl lima-and-qemu.pl alpine
+      timeout-minutes: 10
+      env:
+        VERSION: ${{ steps.version.outputs.VERSION }}
+    - uses: actions/upload-artifact@v4
+      with:
+        name: qemu-${{ steps.version.outputs.VERSION }}-darwin-${{ matrix.arch }}
+        path: qemu-${{ steps.version.outputs.VERSION }}-darwin-${{ matrix.arch }}.tar.gz
         if-no-files-found: error
   linux:
     runs-on: ubuntu-22.04

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,8 +23,8 @@ jobs:
     strategy:
       matrix:
         include:
-        - { arch: aarch64, runs-on: macos-14 }
-        - { arch: x86_64, runs-on: macos-12 }
+        - { arch: aarch64, runs-on: macos-14, use-otool: 1 }
+        - { arch: x86_64, runs-on: macos-12, use-otool: 0 }
     runs-on: ${{ matrix.runs-on }}
     timeout-minutes: 120
     steps:
@@ -50,13 +50,16 @@ jobs:
         set -o xtrace
         brew tap-new rd/tap
         cp qemu.rb "$(brew --repo rd/tap)/Formula/qemu.rb"
+        # Python 3.11, 3.12, and 3.13 are all required to build QEMU and its prerequisites.
+        # At least on macos-12 `brew install` will throw an error on conflicting files, so
+        # we need to install them explicitly with the `--overwrite` option.
         brew install --overwrite --build-from-source $(brew deps --include-build python@3.11)  python@3.11
         brew install --overwrite --build-from-source $(brew deps --include-build python@3.12)  python@3.12
         brew install --overwrite --build-from-source $(brew deps --include-build python@3.13)  python@3.13
         brew install --build-from-source $(brew deps --include-build rd/tap/qemu) rd/tap/qemu
         CACHE=$(brew --cache)
         cp .github/workflows/build.yaml qemu.rb "$CACHE"
-        (cd "$CACHE"; tar -cvzf - *) >qemu-${{ steps.version.outputs.VERSION }}-darwin-source-${{ matrix.arch }}.tar.gz
+        tar -cvz -C "$CACHE" -f "qemu-${{ steps.version.outputs.VERSION }}-darwin-source-${{ matrix.arch }}.tar.gz" .
       env:
         # HOMEBREW_DEBUG: 1
         # HOMEBREW_VERBOSE: 1
@@ -79,12 +82,10 @@ jobs:
         HOMEBREW_NO_INSTALL_CLEANUP: 1
     - run: cpan -Ti JSON
     - run: echo "$PWD/install/bin" >>"$GITHUB_PATH"
-    - run: |
-        export USE_OTOOL=0
-        [[ "${{ matrix.arch }}" == "aarch64" ]] && USE_OTOOL=1
-        perl lima-and-qemu.pl alpine
+    - run: perl lima-and-qemu.pl alpine
       timeout-minutes: 10
       env:
+        USE_OTOOL: ${{ matrix.use-otool }}
         VERSION: ${{ steps.version.outputs.VERSION }}
     - uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 name: build
-on: [ push ]
+on:
+- push
+- pull_request
 permissions:
   contents: read
 jobs:
@@ -77,7 +79,10 @@ jobs:
         HOMEBREW_NO_INSTALL_CLEANUP: 1
     - run: cpan -Ti JSON
     - run: echo "$PWD/install/bin" >>"$GITHUB_PATH"
-    - run: perl lima-and-qemu.pl alpine
+    - run: |
+        export USE_OTOOL=0
+        [[ "${{ matrix.arch }}" == "aarch64" ]] && USE_OTOOL=1
+        perl lima-and-qemu.pl alpine
       timeout-minutes: 10
       env:
         VERSION: ${{ steps.version.outputs.VERSION }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -93,6 +93,13 @@ jobs:
     - uses: actions/checkout@v4
       with:
         persist-credentials: false
+        fetch-depth: 0
+    - id: version
+      name: Calculate version
+      shell: bash
+      run: |
+        version=$(git describe --match 'v[0-9]*' --dirty='.m' --always --tags)
+        echo "VERSION=${version#v}" >>"$GITHUB_OUTPUT"
     - uses: actions/checkout@v4
       with:
         repository: qemu/qemu
@@ -156,10 +163,12 @@ jobs:
     - run: make install DESTDIR=${{ github.workspace }}/install
       working-directory: build
     - run: ./appdir-qemu.sh "${{ github.workspace }}/install/usr"
+      env:
+        VERSION: ${{ steps.version.outputs.VERSION }}
     - uses: actions/upload-artifact@v4
       with:
-        name: qemu-linux-x86_64
-        path: qemu-linux-x86_64.tar.gz
+        name: qemu-${{ steps.version.outputs.VERSION }}-linux-x86_64
+        path: qemu-${{ steps.version.outputs.VERSION }}-linux-x86_64.tar.gz
         if-no-files-found: error
   release:
     if: startsWith(github.ref, 'refs/tags/')

--- a/appdir-qemu.sh
+++ b/appdir-qemu.sh
@@ -46,7 +46,9 @@ set -ex
 [ -d "${1}" ] || error "Directory ${1} doesn't exist"
 
 appDir=$1
-dist="qemu-linux-x86_64"
+dist="qemu"
+[[ -n $VERSION ]] && dist="${dist}-${VERSION}"
+dist="${dist}-linux-x86_64"
 
 # Inspired on linuxdeployqt https://github.com/probonopd/linuxdeployqt/blob/master/tools/linuxdeployqt/excludelist.h
 # Linuxdeployqt is a tool created by probonopd, the AppImage creator

--- a/appdir-qemu.sh
+++ b/appdir-qemu.sh
@@ -46,9 +46,7 @@ set -ex
 [ -d "${1}" ] || error "Directory ${1} doesn't exist"
 
 appDir=$1
-dist="qemu"
-[[ -n $VERSION ]] && dist="${dist}-${VERSION}"
-dist="${dist}-linux-x86_64"
+dist="qemu${VERSION:+-$VERSION}-linux-x86_64"
 
 # Inspired on linuxdeployqt https://github.com/probonopd/linuxdeployqt/blob/master/tools/linuxdeployqt/excludelist.h
 # Linuxdeployqt is a tool created by probonopd, the AppImage creator

--- a/lima-and-qemu.pl
+++ b/lima-and-qemu.pl
@@ -47,8 +47,6 @@ my $arch = $proc =~ /86/ ? "x86_64" : "aarch64";
 
 my %deps;
 chomp(my $install_dir = qx(brew --prefix));
-record("$install_dir/bin/qemu-img");
-record("$install_dir/bin/qemu-system-$arch");
 
 # qemu 6.1.0 doesn't use the symlink to access data files anymore
 # but we need to include it because we replace the symlinks in
@@ -58,70 +56,90 @@ my $name = "$install_dir/share/qemu";
 # Don't call record($name) because we only want the link, not the whole target directory
 $deps{$name} = "→ " . readlink($name);
 
-# Capture any library and datafiles access with FileMonitor
-my $filemonitor = "/tmp/filemonitor.log";
-END { system("sudo pkill FileMonitor") }
-print "sudo may prompt for password to run FileMonitor\n";
-
-#Change this FileMonitor path for local build to installed path
-system("sudo -b filemonitor -skipApple >$filemonitor 2>/dev/null");
-sleep(1) until -s $filemonitor;
-
-chomp(my $lima_dir = qx(brew --prefix lima));
-for my $example (@ARGV) {
-    my $config = "$lima_dir/share/lima/templates/$example.yaml";
-    die "Config $config not found" unless -f $config;
-    system("limactl delete -f $example") if -d "$ENV{HOME}/.lima/$example";
-    system("limactl start --tty=false --cpus 2 --log-level debug $config");
-    system("limactl shell $example uname");
-    system("limactl stop $example");
-    system("limactl delete $example");
-}
-system("sudo pkill FileMonitor");
-
-sleep 10;
-
-open(my $fh, "<", $filemonitor) or die "Can't read $filemonitor: $!";
-while (my $line = <$fh>) {
-    # Only record files opened by qemu-*
-    my $decoded_json;
-    {
-        local $@;
-        eval { $decoded_json = decode_json($line) };
-        next if $@;
-    }
-    my $processName = $decoded_json->{'file'}{'process'}{'name'};
-    my $fileName = $decoded_json->{'file'}{'destination'};
-    next unless $processName =~ /^\s*qemu-/;
-
-    # Skip /opt/homebrew/bin and /usr/local/bin
-    next if $fileName eq "$install_dir/bin";
-    # Ignore files not under /usr/local or /opt/homebrew
-    next unless $fileName =~ /^.*($install_dir\/\S+).*$/;
-    # Skip files that don't exist
-    next unless -e $fileName;
-
-    #Skip if file is already recorded
-    next if exists($deps{$fileName});
-    print "Filename: $fileName \n";
-
-    # find all links of $filename and record.
-    my $links = `find -L  $install_dir/opt -samefile $fileName`;
-    record($fileName);
-    my @arr = split('\n', $links);
-    for my $link (@arr) {
-        #skip if link is already recorded
-        next if exists($deps{$link});
-        record($link);
-    }
-}
-
 # Temporary hack because we can't run qemu aarch64 in CI
 if ($arch eq "aarch64") {
     chomp(my $qemu_dir = qx(brew --prefix qemu));
     record("$qemu_dir/share/qemu/kvmvapic.bin");
     record("$qemu_dir/share/qemu/efi-virtio.rom");
     record("$qemu_dir/share/qemu/vgabios-virtio.bin");
+    record("$qemu_dir/share/qemu/edk2-aarch64-code.fd");
+}
+else {
+    # TODO: need to record x86_64 data files if we want to USE_OTOOL for dependencies
+}
+
+my @deps;
+push @deps, "$install_dir/bin/qemu-img";
+push @deps, "$install_dir/bin/qemu-system-$arch";
+
+if ($ENV{USE_OTOOL}) {
+    while (@deps) {
+        my $dep = shift @deps;
+        next if seen($dep);
+        record($dep);
+        next unless qx(file $dep) =~ /Mach-O/;
+
+        open(my $fh, "otool -L $dep |") or die "Failed to run 'otool -L $dep': $!";
+        while (<$fh>) {
+            my($dylib) = m|^\s+($install_dir/\S+)| or next;
+            push @deps, $dylib unless seen($dylib);
+        }
+        close($fh);
+    }
+}
+else {
+    record($_) for @deps;
+
+    # Capture any library and datafiles access with FileMonitor
+    my $filemonitor = "/tmp/filemonitor.log";
+    if (-f $filemonitor) {
+        print "Re-analyzing existing $filemonitor; delete it to capture new file events\n"
+    }
+    else {
+        eval 'END { system("sudo pkill -9 FileMonitor") }';
+        print "sudo may prompt for password to run FileMonitor\n";
+
+        # Change this FileMonitor path for local build to installed path
+        system("sudo -b filemonitor -skipApple >$filemonitor 2>/dev/null");
+        sleep(1) until -s $filemonitor;
+
+        chomp(my $lima_dir = qx(brew --prefix lima));
+        for my $example (@ARGV) {
+            my $config = "$lima_dir/share/lima/templates/$example.yaml";
+            die "Config $config not found" unless -f $config;
+            system("limactl delete -f $example") if -d "$ENV{HOME}/.lima/$example";
+            system("limactl start --tty=false --vm-type qemu --cpus 2 --log-level debug $config");
+            system("limactl shell $example uname");
+            system("limactl stop $example");
+            system("limactl delete $example");
+        }
+        system("sudo pkill -9 FileMonitor");
+
+        sleep 10;
+    }
+
+    open(my $fh, "<", $filemonitor) or die "Can't read $filemonitor: $!";
+    while (my $line = <$fh>) {
+        next unless $line =~    /^\{.*\}$/;
+        # Only record files opened by qemu-*
+        my $decoded_json = decode_json($line);
+        my $processName = $decoded_json->{'file'}{'process'}{'name'} or next;
+        my $fileName = $decoded_json->{'file'}{'destination'} or next;
+        next unless $processName =~ /^\s*qemu-/;
+
+        # Skip /opt/homebrew/bin and /usr/local/bin
+        next if $fileName =~ m|^.*($install_dir/bin/\S+).*$|;
+        # Ignore files not under /usr/local or /opt/homebrew
+        next unless $fileName =~ m|^.*($install_dir/\S+).*$|;
+        # Skip files that don't exist
+        record($fileName) if -f $fileName;
+    }
+}
+
+# find all links of regular files and record.
+foreach my $file (grep -f, keys %deps) {
+    print "Finding links for $file\n";
+    record($_) for split('\n', `find -L  $install_dir/opt -samefile $file`);
 }
 
 print "$_ $deps{$_}\n" for sort keys %deps;
@@ -216,6 +234,11 @@ exit;
 #   /usr/local/Cellar/libssh/0.9.5_1/lib/libssh.4.8.6.dylib [394K]
 
 my %seen;
+
+sub seen {
+    return $seen{$_[0]};
+}
+
 sub record {
     my $dep = shift;
     return if $seen{$dep}++;

--- a/lima-and-qemu.pl
+++ b/lima-and-qemu.pl
@@ -127,8 +127,18 @@ if ($arch eq "aarch64") {
 print "$_ $deps{$_}\n" for sort keys %deps;
 print "\n";
 
-my $dist = "qemu-darwin-$arch";
+# "qemu-9.1.0-macos12-x86_64"
+my $dist = "qemu";
+$dist .= "-$ENV{VERSION}" if $ENV{VERSION};
+$dist .= "-darwin-$arch";
 system("rm -rf /tmp/$dist");
+
+# Record build information
+my $buildenv = "/tmp/$dist/build-env.txt";
+system("mkdir -p /tmp/$dist");
+system("uname -a >>$buildenv");
+system("sw_vers >>$buildenv");
+system("pkgutil --pkg-info=com.apple.pkg.CLTools_Executables >>$buildenv");
 
 # Copy all files to /tmp tree and make all dylib references relative to the
 # /usr/local/bin directory using @executable_path/..
@@ -191,7 +201,7 @@ for my $attr (("com.apple.FinderInfo", "com.apple.ResourceFork")) {
 
 my $repo_root = $FindBin::Bin;
 unlink("$repo_root/$dist.tar.gz");
-system("tar cvfz $repo_root/$dist.tar.gz -C /tmp/$dist $files");
+system("tar cvfz $repo_root/$dist.tar.gz -C /tmp/$dist build-env.txt $files");
 
 exit;
 


### PR DESCRIPTION
* Build qemu on macOS with an empty brew install, and then archive the cache directory to provide the sources used in the build.

* Include the tag/version string in the artifact tarballs.

* On Linux set `LD_LIBRARY_PATH` for `appdir-qemu.sh` to make sure we capture all the libs

* Provide an alternative `USE_OTOOL` to collect files on macOS. That turned out not to be necessary, but let's keep it in case `filemonitor will at some point require disabling SIP or something like that.

