### PR TITLE
Build QEMU 9.2.0 with patches for Apple M4 by the UTM project

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         include:
         - { arch: aarch64, runs-on: macos-14, use-otool: 1 }
-        - { arch: x86_64, runs-on: macos-12, use-otool: 0 }
+        - { arch: x86_64, runs-on: macos-13, use-otool: 0 }
     runs-on: ${{ matrix.runs-on }}
     timeout-minutes: 120
     steps:
@@ -50,12 +50,11 @@ jobs:
         set -o xtrace
         brew tap-new rd/tap
         cp qemu.rb "$(brew --repo rd/tap)/Formula/qemu.rb"
-        # Python 3.11, 3.12, and 3.13 are all required to build QEMU and its prerequisites.
-        # At least on macos-12 `brew install` will throw an error on conflicting files, so
-        # we need to install them explicitly with the `--overwrite` option.
+        # python@3.13 right now doesn't build from source (fails test_xml_etree_c tests) so install it from bottle for now
+        # install python@3.11 and @3.12 from source first, so we capture the dependencies in source
         brew install --overwrite --build-from-source $(brew deps --include-build python@3.11)  python@3.11
         brew install --overwrite --build-from-source $(brew deps --include-build python@3.12)  python@3.12
-        brew install --overwrite --build-from-source $(brew deps --include-build python@3.13)  python@3.13
+        brew install --overwrite python@3.13
         brew install --build-from-source $(brew deps --include-build rd/tap/qemu) rd/tap/qemu
         CACHE=$(brew --cache)
         cp .github/workflows/build.yaml qemu.rb "$CACHE"
@@ -111,6 +110,8 @@ jobs:
         repository: qemu/qemu
         ref: v9.2.0
         path: qemu
+        fetch-depth: 0
+        submodules: recursive
     - name: Install dependencies
       run: >-
         sudo apt-get update &&

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -109,7 +109,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         repository: qemu/qemu
-        ref: v9.1.2
+        ref: v9.2.0
         path: qemu
     - name: Install dependencies
       run: >-

--- a/qemu.rb
+++ b/qemu.rb
@@ -29,8 +29,8 @@
 class Qemu < Formula
   desc "Generic machine emulator and virtualizer"
   homepage "https://www.qemu.org/"
-  url "https://download.qemu.org/qemu-9.1.2.tar.xz"
-  sha256 "19fd9d7535a54d6e044e186402aa3b3b1bdfa87c392ec8884855592c8510c96f"
+  url "https://download.qemu.org/qemu-9.2.0.tar.xz"
+  sha256 "f859f0bc65e1f533d040bbe8c92bcfecee5af2c921a6687c652fb44d089bd894"
   license "GPL-2.0-only"
   head "https://gitlab.com/qemu-project/qemu.git", branch: "master"
 


### PR DESCRIPTION
qemu: apply `hvf: arm: disable SME which is not properly handled by QEMU`

From https://github.com/utmapp/UTM/blob/v4.6.3/patches/qemu-9.1.2-utm.patch#L714-L741

Needed by macOS 15.2 (or later) on Apple M4 (or later):
- https://gitlab.com/qemu-project/qemu/-/issues/2665
- https://gitlab.com/qemu-project/qemu/-/issues/2721

Also bumps to QEMU 9.2.0 and switches x86_64 build to macos-13 (because macos-12 is no longer available).